### PR TITLE
Reimplement disabling retries on disconnect and IPv6 host parsing support

### DIFF
--- a/src/cluster/connectionPoolBuilder.js
+++ b/src/cluster/connectionPoolBuilder.js
@@ -92,8 +92,15 @@ module.exports = ({
 
         const randomBroker = list[index++ % list.length]
 
-        host = randomBroker.split(':')[0]
-        port = Number(randomBroker.split(':')[1])
+        // awhittier: Works for server:9902, 10.1.2.3:9902, and ::1:9902.
+        const lastColonIdx = randomBroker.lastIndexOf(':')
+        if (lastColonIdx === -1 || lastColonIdx === randomBroker.length - 1) {
+          throw new KafkaJSNonRetriableError(
+            `Failed to connect: host ${randomBroker} did not contain a host and port separated by a colon`
+          )
+        }
+        host = randomBroker.substring(0, lastColonIdx)
+        port = Number(randomBroker.substring(lastColonIdx + 1))
       }
 
       return new ConnectionPool({

--- a/src/producer/index.js
+++ b/src/producer/index.js
@@ -40,6 +40,7 @@ module.exports = ({
   instrumentationEmitter: rootInstrumentationEmitter,
 }) => {
   let connectionStatus = CONNECTION_STATUS.DISCONNECTED
+  let retryEnabled = false
   retry = retry || { retries: idempotent ? Number.MAX_SAFE_INTEGER : 5 }
 
   if (idempotent && retry.retries < 1) {
@@ -73,6 +74,7 @@ module.exports = ({
     idempotent,
     retrier,
     getConnectionStatus: () => connectionStatus,
+    getRetryEnabled: () => retryEnabled,
   })
 
   let transactionalEosManager
@@ -216,6 +218,7 @@ module.exports = ({
      * @returns {Promise}
      */
     connect: async () => {
+      retryEnabled = true
       await cluster.connect()
       connectionStatus = CONNECTION_STATUS.CONNECTED
       instrumentationEmitter.emit(CONNECT)
@@ -228,6 +231,7 @@ module.exports = ({
      * @return {Promise}
      */
     disconnect: async () => {
+      retryEnabled = false
       connectionStatus = CONNECTION_STATUS.DISCONNECTING
       await cluster.disconnect()
       connectionStatus = CONNECTION_STATUS.DISCONNECTED

--- a/src/producer/messageProducer.js
+++ b/src/producer/messageProducer.js
@@ -9,6 +9,7 @@ module.exports = ({
   eosManager,
   idempotent,
   retrier,
+  getRetryEnabled,
   getConnectionStatus,
 }) => {
   const sendMessages = createSendMessages({
@@ -17,6 +18,7 @@ module.exports = ({
     retrier,
     partitioner,
     eosManager,
+    getRetryEnabled,
   })
 
   const validateConnectionStatus = () => {

--- a/src/producer/sendMessages.js
+++ b/src/producer/sendMessages.js
@@ -14,7 +14,7 @@ const { keys } = Object
  * @param {import("./eosManager").EosManager} options.eosManager
  * @param {import("../retry").Retrier} options.retrier
  */
-module.exports = ({ logger, cluster, partitioner, eosManager, retrier }) => {
+module.exports = ({ logger, cluster, partitioner, eosManager, retrier, getRetryEnabled }) => {
   return async ({ acks, timeout, compression, topicMessages }) => {
     /** @type {Map<import("../../types").Broker, any[]>} */
     const responsePerBroker = new Map()
@@ -125,6 +125,12 @@ module.exports = ({ logger, cluster, partitioner, eosManager, retrier }) => {
     }
 
     return retrier(async (bail, retryCount, retryTime) => {
+      const shouldRetry = getRetryEnabled ? getRetryEnabled() : true
+      if (!shouldRetry) {
+        logger.debug(`Retry bailing due to flag`)
+        bail(new Error('Retry bailing due to flag'))
+        return
+      }
       const topics = topicMessages.map(({ topic }) => topic)
       await cluster.addMultipleTargetTopics(topics)
 


### PR DESCRIPTION
Reimplements changes from the following commits to the previous forked kafkajs repo:

https://github.com/tulios/kafkajs/commit/13c4fc87e34e2a65f8f0f2f37c601e89d9585643
https://github.com/tulios/kafkajs/commit/d3eec97297a2f5f00e12584ca40e87e3c160b433
https://github.com/tulios/kafkajs/commit/ce8ceddc5ae24ffff9e5f904dbc4ae6b3b982a74

This does not include the socketFactory changes made to enable Kerberos support - not sure if we're going to go that route for Kerberos support or go the auth plugin route.

To test:

1. Checkout the repo
2. `npm install --global yarn`
3. `yarn install`
4. `yarn test`