### PR TITLE
Reword onCrash error message to avoid using the word 'crash'

### DIFF
--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -244,7 +244,7 @@ module.exports = ({
     }
 
     const onCrash = async e => {
-      logger.error(`Crash: ${e.name}: ${e.message}`, {
+      logger.error(`Error: ${e.name}: ${e.message}`, {
         groupId,
         retryCount: e.retryCount,
         stack: e.stack,


### PR DESCRIPTION
Done as part of CRIBL-18822.