### PR TITLE
CRIBL-27368 Heartbeat more regularly from within (Consumer's) retries 

### DIFF
--- a/src/consumer/runner.js
+++ b/src/consumer/runner.js
@@ -180,7 +180,7 @@ module.exports = class Runner extends EventEmitter {
             },
           })
 
-          throw hbError
+          throw e
         })
 
         this.logger.debug('Error while scheduling fetch manager, trying again...', {

--- a/src/errors.js
+++ b/src/errors.js
@@ -270,6 +270,8 @@ const isRebalancing = e =>
   e.type === 'NOT_COORDINATOR_FOR_GROUP' ||
   e.type === 'ILLEGAL_GENERATION'
 
+const isUnknownMember = e => e.type === 'UNKNOWN_MEMBER_ID'
+
 const isKafkaJSError = e => e instanceof KafkaJSError
 
 module.exports = {
@@ -305,5 +307,6 @@ module.exports = {
   KafkaJSNoBrokerAvailableError,
   KafkaJSAlterPartitionReassignmentsError,
   isRebalancing,
+  isUnknownMember,
   isKafkaJSError,
 }

--- a/src/network/connection.js
+++ b/src/network/connection.js
@@ -260,6 +260,12 @@ module.exports = class Connection {
   }
 
   /**
+   * Terminates a connection. In-flight requests are awaited until completion
+   * before closing the socket. Immediately after invoking this method,
+   * `connectionStatus` will reflect the `CONNECTION_STATUS.DISCONNECTING` status.
+   * Once the connection terminated, the status will be transitioned to
+   * `CONNECTION_STATUS.DISCONNECTED`, and the internals will be reset back to
+   * their original state, making this connection instance ready for reuse.
    * @public
    * @returns {Promise}
    */


### PR DESCRIPTION
The `kafkajs` library can be configured to retry failed operations. Retries are not executed immediately, but according to the built-in mechanism [here](https://kafka.js.org/docs/retry-detailed) explained. One can configure the minimum and maximum amount of time a consumer (or a producer) would go into an idle state before retrying a given operation, but the formula therein described is what calculates the actual delay (there's not 100% predictable as the library uses a randomization factor). One important thing to mention is that the idle time will grow exponentially and reset once the max configured is hit.

So far so good; this works seamlessly probably in most of the cases. Consumer uses the retry framework at 2 different stages (there might be other indirect usages of such): a) when joining a group and b) for polling-and-processing data from topics. When engaged in the second set-up, the mechanism turned out to be a smoking gun in certain cases, potentially harming the health of a consumer, hence the whole consumer-group's. Actually, to be fair, the problem isn't with this mechanism itself, but with how the consumer is using it. Let's review two scenarios that'd hopefully self-describe better the problem here being discussed:

**Quick note**: If you're not familiar with how Kafka works, it's important to understand what session-timeout and heartbeats are, and how they relate to each other. At glance, these are ([source](https://docs.confluent.io/platform/current/installation/configuration/consumer-configs.html#session-timeout-ms)):

**Session timeout** is timeout used to detect client failures when using Kafka’s group management facility. The client sends periodic **heartbeats** to indicate its liveness to the broker. If no heartbeats are received by the broker before the expiration of this session timeout, then the broker will remove this client from the group and initiate a **rebalance**.

From this definition, we can now understand how important is for a consumer to heartbeat in a timely manner to report healthy, thus preventing it from being excluded from a group + the rebalance coming after that. **Rebalances are not a bad thing**, but when triggered out of control they can become so problematic.

### Scenario 1

1. Request timeout is 30s, session timeout is 60s, heartbeat interval is 3s.
2. Consumer joins the group and receives the assignment.
3. Everything works fine for some time: consumer polls and process data, and emits heartbeats on time.
4. Eventually, the connection used for fetching data starts to fail.
5. Consider this t=0, where the consumer has just sent the last heartbeat and it's sending a fetch request.
6. At t=30, the request times out, and the retry mechanism engages.
7. Imagine the initial delay before the retry is 10s so, at t=40, the new request is sent.
8. Request fails a second time. We are at t=70 at this point, which is 10s beyond the session timeout. Next retry delay is 20s.
9. At this point, it's very likely that the group is rebalancing, because of this consumer not heartbeating in a while, hence considered dead.
10. The consumer exhausts the remaining retries and it decides it's time to reconnect.
11. The consumer rejoining the group causes a new rebalance.

#### Conclusion
Due to how the `kafkajs` consumer works, heartbeats are not emitted in between retries. This can be problematic, when a given operation has to be retried several times, and that results in the consumer not hearbeating for a period of time that's greater than the session timeout. Imagine the failure described in this scenario is transient, and that the 3rd or 4rd attempt will succeed. The way most Kafka brokers work, once a consumer gets kicked out from a group, it won't return anything from fetch requests (or even start to reject connections), causing the consumer not to be able to self-recover from the transient failure.

### Scenario 2

1. Request timeout is 30s, session timeout is 60s, rebalance timeout is 90s, heartbeat interval is 3s.
2. Consumer joins the group and receives the assignment.
3. Everything works fine for some time: consumer polls and process data, and emits heartbeats on time.
4. Eventually, the connection used for fetching data starts to fail.
5. Consider this t=0, where the consumer has just sent the last heartbeat and it's sending a fetch request.At t=30, the request times out, and the retry mechanism engages.
6. Imagine the initial delay before the retry is 10s so, at t=40, the new request is sent.
7. Request fails a second time. We are at t=70 at this point, which is fine as the session timeout hasn't expired yet. Next retry delay is 20s.
8. A new consumer joins the group, so the coordinator triggers a rebalance. Existing members are expected to rejoin within the following 90s (rebalance timeout).
9. We're beyond the rebalance timeout when the consumer exhausts the remaining retries and decides it's time to reconnect.
10. The consumer rejoining the group causes a new rebalance.

#### Conclusion
If the consumer were heartbeating on a timely manner, it would have acknowledged the ongoing rebalance thus avoiding the second one.

### Proposed solution
Plug two new heartbeat calls as follows:

1. Before (actually, in parallel) the polling-and-processing task is to be executed, either for the first time or being it a Nth retry. See [here](https://github.com/fbonecco-cribl/kafkajs2/blob/CRIBL-27368-heartbeat-from-runner/src/consumer/runner.js#L152-L1552).
2. Immediately before the consumer will go to sleep/idle (due to backoff formula) before executing the Nth retry. See [here](https://github.com/fbonecco-cribl/kafkajs2/blob/CRIBL-27368-heartbeat-from-runner/src/consumer/runner.js#L183).

#### Other solutions considered...

##### Expose the heartbeat method as part of the Consumer class, so we (Stream) can heartbeat on our own.
We're already doing something similar when we're processing batches. This turned out to be so complicated to test and maintain. Exposing the method isn't a big deal but heartbeating from the outside in a reliable manner would. Blast radius would have been huge and would put the current implementation at a risk.

#### Have the `kafkajs` consumer (this is, within the library itself) heartbeating out-band, independent from the rest of the flows.
This was my preferred choice, and actually have a branch out there with the suggested changes. After thinking more about it, and spending quite some time trying to fix failing UTs, I realized this can't be implemented by just adding _a timer to hearbeat reguarly from the outside_, but that more work is needed, like removing existing existing heartbeat calls that would, otherwise, cause redundant calls. In general, this last part, isn't a problem, but would make the flow harder to follow and predict. I do think we might want to revisit this approach if we're still encountering problems out there, where consumer groups experience an excess of rebalances.

### How to validate:
#### Test suite
Run the whole test suite and make sure it passes. Most of these tests are purely E2E and rely on a real Kafka cluster that gets spun up as part of the yarn test command. That said...the suite is really flakey and it might take you a couple of runs to have them all passing (if you're lucky). Double check the flakiness is also present on the cribl-release and/or master branches.

Check out this repo and branch
1. npm install --global yarn
2. yarn install
3. yarn test

#### Manual testing in Stream
Find the instructions in this PR https://bitbucket.org/cribl/cribl/pull-requests/21207/overview to test this patched version with real Stream.