### PR TITLE
CRIBL-28135 Add id to connections for tracking purposes

### DIFF
--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -201,7 +201,7 @@ module.exports = ({
     }
 
     const start = async onCrash => {
-      logger.info('Starting', { groupId })
+      logger.debug('Starting', { groupId })
 
       consumerGroup = new ConsumerGroup({
         logger: rootLogger,

--- a/src/network/connection.js
+++ b/src/network/connection.js
@@ -54,6 +54,7 @@ module.exports = class Connection {
    * @param {import("../instrumentation/emitter")} [options.instrumentationEmitter=null]
    */
   constructor({
+    id,
     host,
     port,
     logger,
@@ -69,6 +70,7 @@ module.exports = class Connection {
     maxInFlightRequests = null,
     instrumentationEmitter = null,
   }) {
+    this.id = id
     this.host = host
     this.port = port
     this.rack = rack
@@ -239,6 +241,7 @@ module.exports = class Connection {
         timeoutId = setTimeout(onTimeout, this.connectionTimeout)
         this.socket = createSocket({
           socketFactory: this.socketFactory,
+          id: this.id,
           host: this.host,
           port: this.port,
           ssl: this.ssl,

--- a/src/network/connectionPool.js
+++ b/src/network/connectionPool.js
@@ -16,7 +16,7 @@ module.exports = class ConnectionPool {
     this.clientId = options.clientId
     this.socketFactory = options.socketFactory
 
-    this.pool = new Array(2).fill().map(() => new Connection(options))
+    this.pool = new Array(2).fill().map((entry, id) => new Connection({ id, ...options }))
   }
 
   isConnected() {

--- a/src/network/socket.js
+++ b/src/network/socket.js
@@ -12,6 +12,7 @@
  */
 module.exports = ({
   socketFactory,
+  id,
   host,
   port,
   ssl,
@@ -21,7 +22,7 @@ module.exports = ({
   onError,
   onTimeout,
 }) => {
-  const socket = socketFactory({ host, port, ssl, onConnect })
+  const socket = socketFactory({ id, host, port, ssl, onConnect })
 
   socket.on('data', onData)
   socket.on('end', onEnd)

--- a/src/network/socketFactory.js
+++ b/src/network/socketFactory.js
@@ -7,7 +7,7 @@ module.exports = () => {
   const net = require('net')
   const tls = require('tls')
 
-  return ({ host, port, ssl, onConnect }) => {
+  return ({ id, host, port, ssl, onConnect }) => {
     const socket = ssl
       ? tls.connect(
           Object.assign({ host, port }, !net.isIP(host) ? { servername: host } : {}, ssl),

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -64,6 +64,7 @@ export interface KafkaConfig {
 }
 
 export interface ISocketFactoryArgs {
+  id: number
   host: string
   port: number
   ssl: tls.ConnectionOptions


### PR DESCRIPTION
In this PR we're setting ids to connections created using the `socketFactory`. The goal is to be able to identify the type of each connection in Consumers (data or managment), so we can put (on Stream) some on logic on top of this.