### PR TITLE
CRIBL-38012: Add broker API versions discovery instrumentation event

### DIFF
--- a/src/admin/instrumentationEvents.js
+++ b/src/admin/instrumentationEvents.js
@@ -1,5 +1,6 @@
 const swapObject = require('../utils/swapObject')
 const networkEvents = require('../network/instrumentationEvents')
+const brokerEvents = require('../broker/instrumentationEvents')
 const InstrumentationEventType = require('../instrumentation/eventType')
 const adminType = InstrumentationEventType('admin')
 
@@ -9,12 +10,14 @@ const events = {
   REQUEST: adminType(networkEvents.NETWORK_REQUEST),
   REQUEST_TIMEOUT: adminType(networkEvents.NETWORK_REQUEST_TIMEOUT),
   REQUEST_QUEUE_SIZE: adminType(networkEvents.NETWORK_REQUEST_QUEUE_SIZE),
+  BROKER_API_VERSIONS: adminType(brokerEvents.BROKER_API_VERSIONS),
 }
 
 const wrappedEvents = {
   [events.REQUEST]: networkEvents.NETWORK_REQUEST,
   [events.REQUEST_TIMEOUT]: networkEvents.NETWORK_REQUEST_TIMEOUT,
   [events.REQUEST_QUEUE_SIZE]: networkEvents.NETWORK_REQUEST_QUEUE_SIZE,
+  [events.BROKER_API_VERSIONS]: brokerEvents.BROKER_API_VERSIONS,
 }
 
 const reversedWrappedEvents = swapObject(wrappedEvents)

--- a/src/broker/__tests__/brokerApiVersionsEvent.spec.js
+++ b/src/broker/__tests__/brokerApiVersionsEvent.spec.js
@@ -72,6 +72,50 @@ describe('Broker > BROKER_API_VERSIONS event', () => {
     expect(setVersions).toHaveBeenCalledWith(VERSIONS)
   })
 
+  test('emits a deep copy: mutating the payload at any layer does not corrupt the live versions', async () => {
+    // A fresh live object plus an independent pristine snapshot to compare against.
+    // Using the shared VERSIONS const would make the "original unmutated" assertion
+    // compare the object to itself, which cannot catch a leaked reference.
+    const liveVersions = {
+      0: { minVersion: 0, maxVersion: 9 },
+      18: { minVersion: 0, maxVersion: 3 },
+    }
+    const pristine = {
+      0: { minVersion: 0, maxVersion: 9 },
+      18: { minVersion: 0, maxVersion: 3 },
+    }
+
+    const broker = new Broker({
+      connectionPool,
+      logger: newLogger(),
+      nodeId: 7,
+      instrumentationEmitter: emitter,
+    })
+    jest.spyOn(broker, 'apiVersions').mockResolvedValue(liveVersions)
+    let payload
+    emitter.addListener(BROKER_API_VERSIONS, event => {
+      payload = event.payload
+    })
+
+    await broker.connect()
+
+    // The emitted apiVersions is a distinct object graph at every layer, not the live object.
+    expect(payload.apiVersions).not.toBe(liveVersions)
+    expect(payload.apiVersions[18]).not.toBe(liveVersions[18])
+
+    // Mutate the emitted payload at both the top layer (add/remove keys) and the
+    // nested layer (change a version range).
+    payload.apiVersions[42] = { minVersion: 0, maxVersion: 0 }
+    delete payload.apiVersions[0]
+    payload.apiVersions[18].maxVersion = 999
+
+    // The broker still holds the original object, and that object is untouched -- so the
+    // setVersions()/lookup() calls that ran on the same reference saw uncorrupted data.
+    expect(broker.versions).toBe(liveVersions)
+    expect(broker.versions).toEqual(pristine)
+    expect(setVersions).toHaveBeenCalledWith(pristine)
+  })
+
   test('does not emit when api version negotiation fails, and surfaces the error', async () => {
     const broker = new Broker({
       connectionPool,

--- a/src/broker/__tests__/brokerApiVersionsEvent.spec.js
+++ b/src/broker/__tests__/brokerApiVersionsEvent.spec.js
@@ -1,0 +1,157 @@
+const { newLogger } = require('testHelpers')
+
+const InstrumentationEventEmitter = require('../../instrumentation/emitter')
+const { KafkaJSNonRetriableError } = require('../../errors')
+const Broker = require('../index')
+const { BROKER_API_VERSIONS } = require('../instrumentationEvents')
+
+/**
+ * Unit coverage for the BROKER_API_VERSIONS instrumentation event.
+ *
+ * These tests exercise the real Broker#connect() guard logic but mock the
+ * network boundary (connectionPool) and the wire response (apiVersions), so
+ * they run without a live Kafka broker and stay deterministic. The focus is
+ * non-happy paths: failures, opt-out, reconnects, and misbehaving listeners
+ * must not change the connection flow.
+ */
+describe('Broker > BROKER_API_VERSIONS event', () => {
+  const VERSIONS = {
+    0: { minVersion: 0, maxVersion: 9 },
+    18: { minVersion: 0, maxVersion: 3 },
+  }
+
+  let connectionPool, authenticate, setVersions, emitter
+
+  const createFakeConnectionPool = () => {
+    authenticate = jest.fn(async () => {})
+    setVersions = jest.fn()
+    const connection = {
+      // Non-null return skips the SaslAuthenticate lookup block in connect()
+      getSupportAuthenticationProtocol: () => true,
+      authenticate,
+    }
+    return {
+      host: 'kafka.test',
+      port: 9092,
+      clientId: 'test-client',
+      connectionTimeout: 1000,
+      sasl: null,
+      isConnected: jest.fn(() => false),
+      isAuthenticated: jest.fn(() => false),
+      getConnection: jest.fn(async () => connection),
+      setVersions,
+    }
+  }
+
+  beforeEach(() => {
+    connectionPool = createFakeConnectionPool()
+    emitter = new InstrumentationEventEmitter()
+  })
+
+  test('emits exactly once with the broker fingerprint on a successful connect', async () => {
+    const broker = new Broker({
+      connectionPool,
+      logger: newLogger(),
+      nodeId: 7,
+      instrumentationEmitter: emitter,
+    })
+    const apiVersionsSpy = jest.spyOn(broker, 'apiVersions').mockResolvedValue(VERSIONS)
+    const listener = jest.fn()
+    emitter.addListener(BROKER_API_VERSIONS, listener)
+
+    await broker.connect()
+
+    expect(apiVersionsSpy).toHaveBeenCalledTimes(1)
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(listener.mock.calls[0][0].payload).toEqual({
+      broker: 'kafka.test:9092',
+      nodeId: 7,
+      clientId: 'test-client',
+      apiVersions: VERSIONS,
+    })
+    expect(setVersions).toHaveBeenCalledWith(VERSIONS)
+  })
+
+  test('does not emit when api version negotiation fails, and surfaces the error', async () => {
+    const broker = new Broker({
+      connectionPool,
+      logger: newLogger(),
+      instrumentationEmitter: emitter,
+    })
+    jest
+      .spyOn(broker, 'apiVersions')
+      .mockRejectedValue(new KafkaJSNonRetriableError('API Versions not supported'))
+    const listener = jest.fn()
+    emitter.addListener(BROKER_API_VERSIONS, listener)
+
+    await expect(broker.connect()).rejects.toThrow('API Versions not supported')
+
+    expect(listener).not.toHaveBeenCalled()
+    expect(setVersions).not.toHaveBeenCalled()
+    expect(broker.versions).toEqual(null)
+  })
+
+  test('does not emit or re-negotiate when versions are already provided (non-seed broker)', async () => {
+    const broker = new Broker({
+      connectionPool,
+      logger: newLogger(),
+      nodeId: 2,
+      versions: VERSIONS,
+      instrumentationEmitter: emitter,
+    })
+    const apiVersionsSpy = jest.spyOn(broker, 'apiVersions')
+    const listener = jest.fn()
+    emitter.addListener(BROKER_API_VERSIONS, listener)
+
+    await broker.connect()
+
+    expect(apiVersionsSpy).not.toHaveBeenCalled()
+    expect(listener).not.toHaveBeenCalled()
+    expect(setVersions).toHaveBeenCalledWith(VERSIONS)
+  })
+
+  test('connects successfully when no instrumentationEmitter is provided', async () => {
+    const broker = new Broker({ connectionPool, logger: newLogger() })
+    jest.spyOn(broker, 'apiVersions').mockResolvedValue(VERSIONS)
+
+    await expect(broker.connect()).resolves.toBeUndefined()
+
+    expect(setVersions).toHaveBeenCalledWith(VERSIONS)
+    expect(authenticate).toHaveBeenCalledTimes(1)
+  })
+
+  test('emits only once across repeated connect calls (no duplicate telemetry on reconnect)', async () => {
+    const broker = new Broker({
+      connectionPool,
+      logger: newLogger(),
+      instrumentationEmitter: emitter,
+    })
+    const apiVersionsSpy = jest.spyOn(broker, 'apiVersions').mockResolvedValue(VERSIONS)
+    const listener = jest.fn()
+    emitter.addListener(BROKER_API_VERSIONS, listener)
+
+    await broker.connect()
+    await broker.connect()
+
+    expect(apiVersionsSpy).toHaveBeenCalledTimes(1)
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(setVersions).toHaveBeenCalledTimes(2)
+  })
+
+  test('a throwing listener does not break the connection flow', async () => {
+    const broker = new Broker({
+      connectionPool,
+      logger: newLogger(),
+      instrumentationEmitter: emitter,
+    })
+    jest.spyOn(broker, 'apiVersions').mockResolvedValue(VERSIONS)
+    emitter.addListener(BROKER_API_VERSIONS, () => {
+      throw new Error('subscriber blew up')
+    })
+
+    await expect(broker.connect()).resolves.toBeUndefined()
+
+    expect(setVersions).toHaveBeenCalledWith(VERSIONS)
+    expect(authenticate).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/broker/__tests__/instrumentationEventsWiring.spec.js
+++ b/src/broker/__tests__/instrumentationEventsWiring.spec.js
@@ -1,0 +1,36 @@
+const { BROKER_API_VERSIONS } = require('../instrumentationEvents')
+const consumerEvents = require('../../consumer/instrumentationEvents')
+const producerEvents = require('../../producer/instrumentationEvents')
+const adminEvents = require('../../admin/instrumentationEvents')
+
+/**
+ * The broker emits the raw BROKER_API_VERSIONS event name, but subscribers
+ * listen via the namespaced alias (e.g. consumer.events.BROKER_API_VERSIONS).
+ * The wrap/unwrap mapping is what bridges the two -- consumer.on() unwraps the
+ * namespaced name down to the raw broker name to register the listener, then
+ * re-wraps event.type before handing it back. If the wrappedEvents entry is
+ * dropped, the listener silently never fires. These tests guard that bridge.
+ */
+describe('broker api versions event wiring', () => {
+  const cases = [
+    ['consumer', consumerEvents, 'consumer.broker.api_versions'],
+    ['producer', producerEvents, 'producer.broker.api_versions'],
+    ['admin', adminEvents, 'admin.broker.api_versions'],
+  ]
+
+  for (const [name, mod, namespaced] of cases) {
+    describe(name, () => {
+      test('exposes the namespaced event alias', () => {
+        expect(mod.events.BROKER_API_VERSIONS).toEqual(namespaced)
+      })
+
+      test('unwraps the alias to the raw broker event the broker emits', () => {
+        expect(mod.unwrap(mod.events.BROKER_API_VERSIONS)).toEqual(BROKER_API_VERSIONS)
+      })
+
+      test('wraps the raw broker event back into the namespaced alias', () => {
+        expect(mod.wrap(BROKER_API_VERSIONS)).toEqual(mod.events.BROKER_API_VERSIONS)
+      })
+    })
+  }
+})

--- a/src/broker/index.js
+++ b/src/broker/index.js
@@ -4,6 +4,7 @@ const { requests, lookup } = require('../protocol/requests')
 const { KafkaJSNonRetriableError } = require('../errors')
 const apiKeys = require('../protocol/requests/apiKeys')
 const shuffle = require('../utils/shuffle')
+const { BROKER_API_VERSIONS } = require('./instrumentationEvents')
 
 const PRIVATE = {
   SEND_REQUEST: Symbol('private:Broker:sendRequest'),
@@ -32,6 +33,7 @@ module.exports = class Broker {
    * @param {boolean} [options.allowAutoTopicCreation=true] If this and the broker config 'auto.create.topics.enable'
    *                                                are true, topics that don't exist will be created when
    *                                                fetching metadata.
+   * @param {import("../instrumentation/emitter")} [options.instrumentationEmitter=null]
    */
   constructor({
     connectionPool,
@@ -40,6 +42,7 @@ module.exports = class Broker {
     versions = null,
     authenticationTimeout = 10000,
     allowAutoTopicCreation = true,
+    instrumentationEmitter = null,
   }) {
     this.connectionPool = connectionPool
     this.nodeId = nodeId
@@ -48,6 +51,7 @@ module.exports = class Broker {
     this.versions = versions
     this.authenticationTimeout = authenticationTimeout
     this.allowAutoTopicCreation = allowAutoTopicCreation
+    this.instrumentationEmitter = instrumentationEmitter
 
     // The lock timeout has twice the connectionTimeout because the same timeout is used
     // for the first apiVersions call
@@ -87,6 +91,14 @@ module.exports = class Broker {
 
       if (!this.versions) {
         this.versions = await this.apiVersions()
+        if (this.instrumentationEmitter) {
+          this.instrumentationEmitter.emit(BROKER_API_VERSIONS, {
+            broker: this.brokerAddress,
+            nodeId: this.nodeId,
+            clientId: this.connectionPool.clientId,
+            apiVersions: this.versions,
+          })
+        }
       }
       this.connectionPool.setVersions(this.versions)
 

--- a/src/broker/index.js
+++ b/src/broker/index.js
@@ -4,6 +4,7 @@ const { requests, lookup } = require('../protocol/requests')
 const { KafkaJSNonRetriableError } = require('../errors')
 const apiKeys = require('../protocol/requests/apiKeys')
 const shuffle = require('../utils/shuffle')
+const mapValues = require('../utils/mapValues')
 const { BROKER_API_VERSIONS } = require('./instrumentationEvents')
 
 const PRIVATE = {
@@ -99,7 +100,9 @@ module.exports = class Broker {
               broker: this.brokerAddress,
               nodeId: this.nodeId,
               clientId: this.connectionPool.clientId,
-              apiVersions: this.versions,
+              // Emit a deep copy (both layers) so a listener mutating the payload cannot
+              // corrupt the live versions object that setVersions()/lookup() consume below.
+              apiVersions: mapValues(this.versions, version => ({ ...version })),
             })
           } catch (e) {
             this.logger.debug('Failed to emit BROKER_API_VERSIONS event', {

--- a/src/broker/index.js
+++ b/src/broker/index.js
@@ -92,12 +92,21 @@ module.exports = class Broker {
       if (!this.versions) {
         this.versions = await this.apiVersions()
         if (this.instrumentationEmitter) {
-          this.instrumentationEmitter.emit(BROKER_API_VERSIONS, {
-            broker: this.brokerAddress,
-            nodeId: this.nodeId,
-            clientId: this.connectionPool.clientId,
-            apiVersions: this.versions,
-          })
+          // Telemetry only: never let a misbehaving listener break the connection path,
+          // since this emit happens mid-connect (before authenticate).
+          try {
+            this.instrumentationEmitter.emit(BROKER_API_VERSIONS, {
+              broker: this.brokerAddress,
+              nodeId: this.nodeId,
+              clientId: this.connectionPool.clientId,
+              apiVersions: this.versions,
+            })
+          } catch (e) {
+            this.logger.debug('Failed to emit BROKER_API_VERSIONS event', {
+              broker: this.brokerAddress,
+              error: e.message,
+            })
+          }
         }
       }
       this.connectionPool.setVersions(this.versions)

--- a/src/broker/instrumentationEvents.js
+++ b/src/broker/instrumentationEvents.js
@@ -1,0 +1,6 @@
+const InstrumentationEventType = require('../instrumentation/eventType')
+const eventType = InstrumentationEventType('broker')
+
+module.exports = {
+  BROKER_API_VERSIONS: eventType('api_versions'),
+}

--- a/src/cluster/brokerPool.js
+++ b/src/cluster/brokerPool.js
@@ -19,6 +19,7 @@ module.exports = class BrokerPool {
    * @param {boolean} [options.allowAutoTopicCreation]
    * @param {number} [options.authenticationTimeout]
    * @param {number} [options.metadataMaxAge]
+   * @param {import("../instrumentation/emitter")} [options.instrumentationEmitter]
    */
   constructor({
     connectionPoolBuilder,
@@ -27,6 +28,7 @@ module.exports = class BrokerPool {
     allowAutoTopicCreation,
     authenticationTimeout,
     metadataMaxAge,
+    instrumentationEmitter = null,
   }) {
     this.rootLogger = logger
     this.connectionPoolBuilder = connectionPoolBuilder
@@ -39,6 +41,7 @@ module.exports = class BrokerPool {
       new Broker({
         allowAutoTopicCreation,
         authenticationTimeout,
+        instrumentationEmitter,
         ...options,
       })
 

--- a/src/cluster/index.js
+++ b/src/cluster/index.js
@@ -101,6 +101,7 @@ module.exports = class Cluster {
       allowAutoTopicCreation,
       authenticationTimeout,
       metadataMaxAge,
+      instrumentationEmitter,
     })
     this.committedOffsetsByGroup = offsets
 

--- a/src/consumer/__tests__/instrumentationEvents.spec.js
+++ b/src/consumer/__tests__/instrumentationEvents.spec.js
@@ -519,6 +519,26 @@ describe('Consumer > Instrumentation Events', () => {
     })
   })
 
+  it('emits broker api versions', async () => {
+    const brokerApiVersionsListener = jest.fn().mockName('broker_api_versions')
+
+    consumer = createTestConsumer()
+    consumer.on(consumer.events.BROKER_API_VERSIONS, brokerApiVersionsListener)
+
+    await consumer.connect()
+    expect(brokerApiVersionsListener).toHaveBeenCalledWith({
+      id: expect.any(Number),
+      timestamp: expect.any(Number),
+      type: 'consumer.broker.api_versions',
+      payload: {
+        broker: expect.any(String),
+        nodeId: null,
+        clientId: expect.any(String),
+        apiVersions: expect.any(Object),
+      },
+    })
+  })
+
   it('emits request timeout events', async () => {
     cluster = createCluster({
       instrumentationEmitter: emitter,

--- a/src/consumer/instrumentationEvents.js
+++ b/src/consumer/instrumentationEvents.js
@@ -1,6 +1,7 @@
 const swapObject = require('../utils/swapObject')
 const InstrumentationEventType = require('../instrumentation/eventType')
 const networkEvents = require('../network/instrumentationEvents')
+const brokerEvents = require('../broker/instrumentationEvents')
 const consumerType = InstrumentationEventType('consumer')
 
 /** @type {import('types').ConsumerEvents} */
@@ -21,12 +22,14 @@ const events = {
   REQUEST: consumerType(networkEvents.NETWORK_REQUEST),
   REQUEST_TIMEOUT: consumerType(networkEvents.NETWORK_REQUEST_TIMEOUT),
   REQUEST_QUEUE_SIZE: consumerType(networkEvents.NETWORK_REQUEST_QUEUE_SIZE),
+  BROKER_API_VERSIONS: consumerType(brokerEvents.BROKER_API_VERSIONS),
 }
 
 const wrappedEvents = {
   [events.REQUEST]: networkEvents.NETWORK_REQUEST,
   [events.REQUEST_TIMEOUT]: networkEvents.NETWORK_REQUEST_TIMEOUT,
   [events.REQUEST_QUEUE_SIZE]: networkEvents.NETWORK_REQUEST_QUEUE_SIZE,
+  [events.BROKER_API_VERSIONS]: brokerEvents.BROKER_API_VERSIONS,
 }
 
 const reversedWrappedEvents = swapObject(wrappedEvents)

--- a/src/producer/index.spec.js
+++ b/src/producer/index.spec.js
@@ -226,6 +226,31 @@ describe('Producer', () => {
     })
   })
 
+  test('emits the broker api versions event', async () => {
+    const emitter = new InstrumentationEventEmitter()
+    producer = createProducer({
+      logger: newLogger(),
+      cluster: createCluster({ instrumentationEmitter: emitter }),
+      instrumentationEmitter: emitter,
+    })
+
+    const brokerApiVersionsListener = jest.fn().mockName('broker_api_versions')
+    producer.on(producer.events.BROKER_API_VERSIONS, brokerApiVersionsListener)
+
+    await producer.connect()
+    expect(brokerApiVersionsListener).toHaveBeenCalledWith({
+      id: expect.any(Number),
+      timestamp: expect.any(Number),
+      type: 'producer.broker.api_versions',
+      payload: {
+        broker: expect.any(String),
+        nodeId: null,
+        clientId: expect.any(String),
+        apiVersions: expect.any(Object),
+      },
+    })
+  })
+
   test('emits the request timeout event', async () => {
     const emitter = new InstrumentationEventEmitter()
     const cluster = createCluster({

--- a/src/producer/instrumentationEvents.js
+++ b/src/producer/instrumentationEvents.js
@@ -1,5 +1,6 @@
 const swapObject = require('../utils/swapObject')
 const networkEvents = require('../network/instrumentationEvents')
+const brokerEvents = require('../broker/instrumentationEvents')
 const InstrumentationEventType = require('../instrumentation/eventType')
 const producerType = InstrumentationEventType('producer')
 
@@ -9,12 +10,14 @@ const events = {
   REQUEST: producerType(networkEvents.NETWORK_REQUEST),
   REQUEST_TIMEOUT: producerType(networkEvents.NETWORK_REQUEST_TIMEOUT),
   REQUEST_QUEUE_SIZE: producerType(networkEvents.NETWORK_REQUEST_QUEUE_SIZE),
+  BROKER_API_VERSIONS: producerType(brokerEvents.BROKER_API_VERSIONS),
 }
 
 const wrappedEvents = {
   [events.REQUEST]: networkEvents.NETWORK_REQUEST,
   [events.REQUEST_TIMEOUT]: networkEvents.NETWORK_REQUEST_TIMEOUT,
   [events.REQUEST_QUEUE_SIZE]: networkEvents.NETWORK_REQUEST_QUEUE_SIZE,
+  [events.BROKER_API_VERSIONS]: brokerEvents.BROKER_API_VERSIONS,
 }
 
 const reversedWrappedEvents = swapObject(wrappedEvents)

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -378,6 +378,7 @@ export type AdminEvents = {
   REQUEST: 'admin.network.request'
   REQUEST_TIMEOUT: 'admin.network.request_timeout'
   REQUEST_QUEUE_SIZE: 'admin.network.request_queue_size'
+  BROKER_API_VERSIONS: 'admin.broker.api_versions'
 }
 
 export interface InstrumentationEvent<T> {
@@ -419,6 +420,12 @@ export type RequestQueueSizeEvent = InstrumentationEvent<{
   broker: string
   clientId: string
   queueSize: number
+}>
+export type BrokerApiVersionsEvent = InstrumentationEvent<{
+  broker: string
+  nodeId: number | null
+  clientId: string
+  apiVersions: ApiVersions
 }>
 
 export type SeekEntry = PartitionOffset
@@ -570,6 +577,10 @@ export type Admin = {
   on(
     eventName: AdminEvents['REQUEST_TIMEOUT'],
     listener: (event: RequestTimeoutEvent) => void
+  ): RemoveInstrumentationEventListener<typeof eventName>
+  on(
+    eventName: AdminEvents['BROKER_API_VERSIONS'],
+    listener: (event: BrokerApiVersionsEvent) => void
   ): RemoveInstrumentationEventListener<typeof eventName>
   on(
     eventName: ValueOf<AdminEvents>,
@@ -783,6 +794,7 @@ export type ProducerEvents = {
   REQUEST: 'producer.network.request'
   REQUEST_TIMEOUT: 'producer.network.request_timeout'
   REQUEST_QUEUE_SIZE: 'producer.network.request_queue_size'
+  BROKER_API_VERSIONS: 'producer.broker.api_versions'
 }
 
 export type Producer = Sender & {
@@ -809,6 +821,10 @@ export type Producer = Sender & {
   on(
     eventName: ProducerEvents['REQUEST_TIMEOUT'],
     listener: (event: RequestTimeoutEvent) => void
+  ): RemoveInstrumentationEventListener<typeof eventName>
+  on(
+    eventName: ProducerEvents['BROKER_API_VERSIONS'],
+    listener: (event: BrokerApiVersionsEvent) => void
   ): RemoveInstrumentationEventListener<typeof eventName>
   on(
     eventName: ValueOf<ProducerEvents>,
@@ -914,6 +930,7 @@ export type ConsumerEvents = {
   REQUEST: 'consumer.network.request'
   REQUEST_TIMEOUT: 'consumer.network.request_timeout'
   REQUEST_QUEUE_SIZE: 'consumer.network.request_queue_size'
+  BROKER_API_VERSIONS: 'consumer.broker.api_versions'
 }
 export type ConsumerHeartbeatEvent = InstrumentationEvent<{
   groupId: string
@@ -1105,6 +1122,10 @@ export type Consumer = {
   on(
     eventName: ConsumerEvents['REQUEST_QUEUE_SIZE'],
     listener: (event: RequestQueueSizeEvent) => void
+  ): RemoveInstrumentationEventListener<typeof eventName>
+  on(
+    eventName: ConsumerEvents['BROKER_API_VERSIONS'],
+    listener: (event: BrokerApiVersionsEvent) => void
   ): RemoveInstrumentationEventListener<typeof eventName>
   on(
     eventName: ValueOf<ConsumerEvents>,

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -58,6 +58,11 @@ let removeListener = consumer.on(consumer.events.HEARTBEAT, e =>
 )
 removeListener()
 
+removeListener = consumer.on(consumer.events.BROKER_API_VERSIONS, e =>
+  console.log(`broker ${e.payload.broker} api versions`, e.payload.apiVersions)
+)
+removeListener()
+
 const runConsumer = async () => {
   await consumer.connect()
   await consumer.subscribe({ topics: [topic] })


### PR DESCRIPTION
  ## Summary

  Adds a `BROKER_API_VERSIONS` instrumentation event to the KafkaJS fork so the broker's negotiated `ApiVersions` map can be observed without opening a second connection. The event fires once per cluster connect, from the seed broker, carrying `{ broker, nodeId, clientId, apiVersions }`. It is a no-op when nobody subscribes, so there should be zero behavior change for existing users.

This is the fork-side half of CRIBL-38012 (Kafka broker version discovery for the `@platformatic/kafka` migration). It is an alternative solution to the probing proposed in https://bitbucket.org/cribl/cribl/pull-requests/41192, with a separate KafkaJS client (extra TCP/TLS/SASL handshake per source/dest start, etc). Riding the existing emitter infrastructure keeps the blast radius small.

## What changed

  **`e89f884a` — instrumentation event**
  - `src/broker/instrumentationEvents.js` (new): defines `BROKER_API_VERSIONS` (`broker.api_versions`).
  - `src/broker/index.js`: accepts an `instrumentationEmitter` and emits the event in `connect()` right after `apiVersions()` resolves, guarded by `if (this.instrumentationEmitter)`.
  - `src/cluster/index.js`, `src/cluster/brokerPool.js`: thread the emitter from Cluster down to each Broker.
  - `src/consumer|producer|admin/instrumentationEvents.js`: re-expose the event under each client namespace (`consumer.broker.api_versions`, etc.) with correct wrap/unwrap.

  **`058efcfd` — types + tests**
  - `types/index.d.ts`: `BROKER_API_VERSIONS` added to `AdminEvents`/`ConsumerEvents`/`ProducerEvents`, new `BrokerApiVersionsEvent` payload type (reusing `ApiVersions`), and typed `on(...)` overloads for all three clients.
  - `types/tests.ts`: type-level usage so `tsc -p types/` covers the new overload.
  - `src/consumer/__tests__/instrumentationEvents.spec.js`, `src/producer/index.spec.js`: integration tests asserting the event fires on connect with the expected payload.

  ## How it's consumed

  ```js
  consumer.on(consumer.events.BROKER_API_VERSIONS, ({ payload }) => {
    // payload: { broker, nodeId, clientId, apiVersions: { [apiKey]: { minVersion, maxVersion } } }
  })
```